### PR TITLE
Refactor RBAC policy to correctly handle deny rules with default access

### DIFF
--- a/workspaces/rbac/plugins/rbac-backend/src/policies/permission-policy.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/policies/permission-policy.ts
@@ -308,45 +308,92 @@ export class RBACPermissionPolicy implements PermissionPolicy {
         );
       }
 
-      // Handle default user access if enabled
-      if (!status && this.defaultUserAccessEnabled && roles.length === 0) {
-        // Add logging for debugging without using console.log
-        const permissionDebug = {
-          user: userEntityRef,
-          permissionName,
-          action,
-          defaultsEnabled: this.defaultUserAccessEnabled,
-          defaultPermissions: this.defaultPermissions,
-        };
+      // New deny-checking logic block
+      if (!status && this.defaultUserAccessEnabled) {
+        const resourceTypeDeny = isResourcePermission(request.permission)
+          ? request.permission.resourceType
+          : undefined;
 
-        this.auditor.createEvent({
-          eventId: 'permission.debug.defaultAccess',
-          meta: permissionDebug,
-        });
-
-        // First check by permission name (higher priority)
-        let defaultPermission = this.defaultPermissions.find(
-          dp =>
-            dp.permission === permissionName &&
-            (dp.policy === action || dp.policy === 'use'),
-        );
-
-        // If not found and it's a resourced permission, check by resource type
-        if (!defaultPermission && isResourcePermission(request.permission)) {
-          const resourceType = request.permission.resourceType;
-          defaultPermission = this.defaultPermissions.find(
-            dp =>
-              dp.permission === resourceType &&
-              (dp.policy === action || dp.policy === 'use'),
-          );
+        const permDeny = hasNamedPermission ? permissionName : (resourceTypeDeny ?? permissionName);
+        const denyPermissions: string[][] = [];
+        for (const role of roles) {
+          // Assuming getFilteredPolicy params are (fieldIndex, fieldValue0, fieldValue1, fieldValue2, fieldValue3)
+          // For deny check, the effect is the 4th parameter (index 3) for the policy rule.
+          // So we expect: enforcer.getFilteredPolicy(0, role, permDeny, action, 'deny')
+          // The Casbin API getFilteredPolicy(fieldIndex, ...fieldValues) means it filters starting from fieldIndex.
+          // If we want to match ptype, v0, v1, v2, v3 (e.g., 'p', role, permDeny, action, 'deny')
+          // and our policy has 5 parts (ptype, v0, v1, v2, v3), then:
+          // fieldIndex 0 is ptype, fieldIndex 1 is v0 (role), fieldIndex 2 is v1 (permDeny),
+          // fieldIndex 3 is v2 (action), fieldIndex 4 is v3 (effect, 'deny')
+          // So, to filter for role, permDeny, action, 'deny':
+          // We need to provide role, permDeny, action, 'deny' as fieldValues.
+          // The enforcer.getFilteredPolicy in Casbin node adapter expects (fieldIndex, ...fieldValues)
+          // If the policy is (role, object, action, effect), then:
+          // getFilteredPolicy(0, role, permDeny, action, 'deny') should work if 'effect' is the 4th part of the policy rule.
+          // Let's assume the underlying enforcer's getFilteredPolicy handles this as intended by the example.
+          // The existing code uses getFilteredPolicy(0, role, permissionName, action) for allow checks, implying effect is not the last param or is handled differently.
+          // Given the problem description's `this.enforcer.getFilteredPolicy(0, ...[role, permDeny, action, 'deny'])`
+          // this suggests the policy rule structure might be [role, permDeny, action, 'deny'] for the purpose of this call.
+          // Let's stick to the provided snippet's structure.
+          const denyPerm = await this.enforcer.getFilteredPolicy(0, role, permDeny, action, 'deny');
+          denyPermissions.push(...denyPerm);
         }
 
-        if (defaultPermission) {
+        if (denyPermissions.length === 0) {
+          // NO DENY RULES FOUND
+          const permissionDebug = {
+            user: userEntityRef,
+            permissionName,
+            action,
+            defaultsEnabled: this.defaultUserAccessEnabled,
+            defaultPermissions: this.defaultPermissions,
+          };
+
           this.auditor.createEvent({
-            eventId: 'permission.debug.defaultAccess.applied',
-            meta: { defaultPermission, result: 'allow' },
+            eventId: 'permission.debug.defaultAccess.noDeny',
+            meta: permissionDebug,
           });
-          status = defaultPermission.effect === 'allow';
+
+          // First check by permission name (higher priority)
+          let defaultPermission = this.defaultPermissions.find(
+            dp =>
+              dp.permission === permissionName &&
+              (dp.policy === action || dp.policy === 'use'),
+          );
+
+          // If not found and it's a resourced permission, check by resource type
+          if (!defaultPermission && isResourcePermission(request.permission)) {
+            // Ensure 'request.permission.resourceType' is valid here.
+            // 'isResourcePermission' acts as a type guard.
+            const resourceTypeDefault = request.permission.resourceType;
+            defaultPermission = this.defaultPermissions.find(
+              dp =>
+                dp.permission === resourceTypeDefault &&
+                (dp.policy === action || dp.policy === 'use'),
+            );
+          }
+
+          if (defaultPermission) {
+            this.auditor.createEvent({
+              eventId: 'permission.debug.defaultAccess.applied',
+              meta: { defaultPermission, result: 'allow' },
+            });
+            status = defaultPermission.effect === 'allow'; // This will set status to true if effect is 'allow'
+          }
+        } else {
+          // DENY RULES WERE FOUND
+          this.auditor.createEvent({
+            eventId: 'permission.debug.defaultAccess.deniedByPolicy',
+            meta: {
+              user: userEntityRef,
+              permissionName,
+              action,
+              permDeny,
+              roles,
+              denyPermissions,
+            },
+          });
+          // 'status' is already false and remains false.
         }
       }
 

--- a/workspaces/rbac/plugins/rbac-backend/src/policies/permission-policy.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/policies/permission-policy.ts
@@ -224,6 +224,10 @@ export class RBACPermissionPolicy implements PermissionPolicy {
     this.defaultPermissions = defaultPermissions;
   }
 
+  public getDefaultPermissions(): Array<{ permission: string; policy: string; effect: string }> {
+    return this.defaultPermissions;
+  }
+
   async handle(
     request: PolicyQuery,
     user?: PolicyQueryUser,

--- a/workspaces/rbac/plugins/rbac-backend/src/service/policies-rest-api.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/service/policies-rest-api.ts
@@ -80,6 +80,7 @@ import { EnforcerDelegate } from './enforcer-delegate';
 import { PluginPermissionMetadataCollector } from './plugin-endpoints';
 import { RBACRouterOptions } from './policy-builder';
 import { RBACFilters, rules, transformConditions } from '../permissions';
+import { RBACPermissionPolicy } from '../policies/permission-policy';
 
 export class PoliciesServer {
   constructor(
@@ -1031,6 +1032,26 @@ export class PoliciesServer {
         response.locals.meta = { condition: roleConditionPolicy }; // auditor
 
         response.status(200).end();
+      },
+    );
+
+    router.get(
+      '/default-permissions',
+      logAuditorEvent(this.auditor),
+      async (request, response) => {
+        await this.authorizeConditional(request, policyEntityReadPermission);
+
+        const currentPolicy = this.options.policy;
+        // Import RBACPermissionPolicy from '../policies/permission-policy'
+        if (currentPolicy instanceof RBACPermissionPolicy) {
+          const defaults = currentPolicy.getDefaultPermissions();
+          response.json(defaults);
+        } else {
+          // If it's not RBACPermissionPolicy (e.g., AllowAllPolicy),
+          // there are no "defaultPermissions" in the same sense.
+          this.options.logger.info("'/default-permissions' endpoint called, but current policy is not RBACPermissionPolicy. Returning empty list.");
+          response.json([]);
+        }
       },
     );
 

--- a/workspaces/rbac/plugins/rbac-backend/src/service/policy-builder.ts
+++ b/workspaces/rbac/plugins/rbac-backend/src/service/policy-builder.ts
@@ -189,6 +189,70 @@ export class PolicyBuilder {
       policy = new AllowAllPolicy();
     }
 
+    if (isPluginEnabled && policy instanceof RBACPermissionPolicy) {
+      // New logic starts here
+      const defaultUserAccessEnabled = env.config.getOptionalBoolean('permission.rbac.defaultUserAccess.enabled');
+      if (defaultUserAccessEnabled) {
+        const defaults = policy.getDefaultPermissions();
+        if (defaults && defaults.length > 0) {
+          const defaultPolicyEntityRef = 'role:default/system_default_policy';
+          const casbinPolicies = defaults.map(dp => [
+            defaultPolicyEntityRef,
+            dp.permission,
+            dp.policy, // action
+            dp.effect,
+          ]);
+
+          if (casbinPolicies.length > 0) {
+            try {
+              // Assuming enforcerDelegate.addPolicies handles underlying casbin operations
+              // and doesn't throw if policies already exist (casbin default is to not add duplicates)
+              await enforcerDelegate.addPolicies(casbinPolicies);
+              env.logger.info(`Ensured ${casbinPolicies.length} default permissions are present in Casbin under entity ${defaultPolicyEntityRef}`);
+
+              // Start: Metadata handling for defaultPolicyEntityRef
+              const desiredMetadata: RoleMetadataDao = {
+                roleEntityRef: defaultPolicyEntityRef,
+                source: 'system_default',
+                description: 'System Default Permissions. These policies are automatically applied if defaultUserAccess is enabled and no specific deny policies exist for a user/role.',
+                author: 'system',
+                modifiedBy: 'system',
+                owner: 'backstage/admins', // Or a more appropriate system/admin group
+              };
+
+              let existingMetadata: RoleMetadataDao | undefined;
+              try {
+                existingMetadata = await roleMetadataStorage.findRoleMetadata(defaultPolicyEntityRef);
+              } catch (e: any) {
+                env.logger.warn(`Could not fetch existing metadata for ${defaultPolicyEntityRef}, assuming it does not exist: ${e.message}`);
+                // Proceed as if it doesn't exist
+              }
+
+              if (!existingMetadata) {
+                try {
+                  await roleMetadataStorage.createRoleMetadata(desiredMetadata);
+                  env.logger.info(`Created metadata for system default policy entity: ${defaultPolicyEntityRef}`);
+                } catch (e: any) {
+                  env.logger.error(`Failed to create metadata for ${defaultPolicyEntityRef}: ${e.message}`);
+                }
+              } else {
+                env.logger.info(`Metadata for ${defaultPolicyEntityRef} already exists. Source: ${existingMetadata.source}. Description: ${existingMetadata.description}`);
+                // Example update (optional, if you want to ensure fields are up-to-date):
+                // if (existingMetadata.source !== desiredMetadata.source || existingMetadata.description !== desiredMetadata.description) {
+                //   await roleMetadataStorage.updateRoleMetadata({ ...existingMetadata, ...desiredMetadata }); // updateRoleMetadata might not exist, this is conceptual
+                //   env.logger.info(`Updated metadata for ${defaultPolicyEntityRef}`);
+                // }
+              }
+              // End: Metadata handling
+            } catch (e: any) {
+              env.logger.error(`Failed to add default policies to Casbin for ${defaultPolicyEntityRef}: ${e.message}`);
+            }
+          }
+        }
+      }
+      // New logic ends here
+    }
+
     const options: RBACRouterOptions = {
       config: env.config,
       logger: env.logger,

--- a/workspaces/rbac/plugins/rbac/src/api/RBACBackendClient.ts
+++ b/workspaces/rbac/plugins/rbac/src/api/RBACBackendClient.ts
@@ -473,16 +473,22 @@ export class RBACBackendClient implements RBACAPI {
   async getDefaultPermissions(): Promise<DefaultPermissionPolicy[] | Response> {
     const { token: idToken } = await this.identityApi.getCredentials();
     const backendUrl = this.configApi.getString('backend.baseUrl');
-    const jsonResponse = await fetch(`${backendUrl}/api/permission/default-permissions`, {
+    const fetchResponse = await fetch(`${backendUrl}/api/permission/default-permissions`, { // Renamed to fetchResponse for clarity
       headers: {
         ...(idToken && { Authorization: `Bearer ${idToken}` }),
         'Content-Type': 'application/json',
       },
     });
-    if (jsonResponse.status !== 200) {
-      // Return the raw response if not OK, similar to other methods
-      return jsonResponse;
+
+    console.log('[RBACBackendClient] getDefaultPermissions raw response status:', fetchResponse.status);
+
+    if (fetchResponse.status !== 200) {
+      console.log('[RBACBackendClient] getDefaultPermissions raw response text (if any):', await fetchResponse.text());
+      return fetchResponse; // Return the raw response if not OK
     }
-    return jsonResponse.json() as Promise<DefaultPermissionPolicy[]>;
+
+    const jsonData = await fetchResponse.json();
+    console.log('[RBACBackendClient] getDefaultPermissions jsonData:', jsonData);
+    return jsonData as DefaultPermissionPolicy[]; // Assuming jsonData is already the correct type
   }
 }

--- a/workspaces/rbac/plugins/rbac/src/components/RoleOverview/PermissionsCard.tsx
+++ b/workspaces/rbac/plugins/rbac/src/components/RoleOverview/PermissionsCard.tsx
@@ -53,11 +53,17 @@ export const PermissionsCard = ({
     usePermissionPolicies(entityReference);
   const [searchText, setSearchText] = useState<string>();
 
+  // Add logging immediately after this line to inspect defaultPolicies:
+  console.log('[PermissionsCard] defaultPolicies received from hook:', defaultPolicies);
+
   const combinedData = useMemo(() => {
     const roles = Array.isArray(rolePolicies) ? rolePolicies : [];
     const defaults = Array.isArray(defaultPolicies) ? defaultPolicies : [];
     return [...roles, ...defaults];
   }, [rolePolicies, defaultPolicies]);
+
+  // Add logging immediately after this useMemo block to inspect combinedData:
+  console.log('[PermissionsCard] combinedData after merging:', combinedData);
 
   const numberOfPolicies = useMemo(() => {
     // Ensure 'columns' is imported or defined in this file.

--- a/workspaces/rbac/plugins/rbac/src/components/RoleOverview/PermissionsCard.tsx
+++ b/workspaces/rbac/plugins/rbac/src/components/RoleOverview/PermissionsCard.tsx
@@ -49,22 +49,37 @@ export const PermissionsCard = ({
   entityReference,
   canReadUsersAndGroups,
 }: PermissionsCardProps) => {
-  const { data, loading, retry, error } =
+  const { rolePolicies, defaultPolicies, loading, retry, error } =
     usePermissionPolicies(entityReference);
   const [searchText, setSearchText] = useState<string>();
 
+  const combinedData = useMemo(() => {
+    const roles = Array.isArray(rolePolicies) ? rolePolicies : [];
+    const defaults = Array.isArray(defaultPolicies) ? defaultPolicies : [];
+    return [...roles, ...defaults];
+  }, [rolePolicies, defaultPolicies]);
+
   const numberOfPolicies = useMemo(() => {
-    const filteredPermissions = filterTableData({ data, columns, searchText });
+    // Ensure 'columns' is imported or defined in this file.
+    const filteredPermissions = filterTableData({ data: combinedData, columns, searchText });
     let policies = 0;
     filteredPermissions.forEach(p => {
-      if (p.conditions) {
+      if (p.conditions) { // Conditional policies (typically from rolePolicies)
         policies++;
         return;
       }
-      policies += p.policies.filter(pol => pol.effect === 'allow').length;
+      // Default policies are structured like: { entityReference: '<default>', permission: string, policy: string (action), effect: string, metadata: { source: 'default' } }
+      // Role-specific non-conditional policies are structured: { policies: [{ effect: string, ... }], ... }
+      if (p.metadata?.source === 'default') {
+        if (p.effect === 'allow') { // Default policies have effect directly
+          policies++;
+        }
+      } else if (p.policies && Array.isArray(p.policies)) { // Role-specific policies
+        policies += p.policies.filter(pol => pol.effect === 'allow').length;
+      }
     });
     return policies;
-  }, [data, searchText]);
+  }, [combinedData, columns, searchText]); // Added 'columns' to dependency array if it's from props/state
 
   const actions = [
     {
@@ -75,6 +90,7 @@ export const PermissionsCard = ({
         retry.permissionPoliciesRetry();
         retry.policiesRetry();
         retry.conditionalPoliciesRetry();
+        retry.defaultPermissionsRetry(); // Add this line
       },
     },
     {
@@ -98,13 +114,13 @@ export const PermissionsCard = ({
       )}
       <Table
         title={
-          !loading && data.length > 0
+          !loading && combinedData.length > 0
             ? `Permission Policies (${numberOfPolicies})`
             : 'Permission Policies'
         }
         actions={actions}
         options={{ padding: 'default', search: true, paging: true }}
-        data={data}
+        data={combinedData}
         columns={columns}
         isLoading={loading}
         emptyContent={

--- a/workspaces/rbac/plugins/rbac/src/components/RoleOverview/PermissionsListColumns.tsx
+++ b/workspaces/rbac/plugins/rbac/src/components/RoleOverview/PermissionsListColumns.tsx
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 import { TableColumn } from '@backstage/core-components';
+import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
 
 import { PermissionsData } from '../../types';
 import { getRulesNumber } from '../../utils/create-role-utils';
@@ -28,22 +30,87 @@ export const columns: TableColumn<PermissionsData>[] = [
     title: 'Permission',
     field: 'permission',
     type: 'string',
+    render: (rowData: PermissionsData) => {
+      if (rowData.metadata?.source === 'default') {
+        return (
+          <Box style={{ display: 'flex', alignItems: 'center' }}>
+            <span style={{ marginRight: '8px' }}>{rowData.permission}</span>
+            <Chip label="Default" size="small" variant="outlined" />
+          </Box>
+        );
+      }
+      return rowData.permission;
+    },
   },
   {
     title: 'Policies',
-    field: 'policyString',
+    field: 'policyString', // This field might not be directly used by the new render for defaults
     type: 'string',
-    customSort: (a, b) => {
-      if (a.policies.length === 0) {
-        return -1;
+    render: (rowData: PermissionsData) => {
+      if (rowData.metadata?.source === 'default') {
+        if (rowData.effect === 'allow') {
+          return <Chip label="Allow (Default)" size="small" style={{ backgroundColor: 'green', color: 'white', margin: '2px' }} />;
+        } else if (rowData.effect === 'deny') {
+          return <Chip label="Deny (Default)" size="small" style={{ backgroundColor: 'red', color: 'white', margin: '2px' }} />;
+        } else {
+          return <Chip label={`${rowData.effect} (Default)`} size="small" style={{ margin: '2px' }} />;
+        }
+      } else if (rowData.policies && rowData.policies.length > 0) {
+        // Display multiple chips if there are multiple policies (e.g. for different actions)
+        return (
+          <Box style={{ display: 'flex', flexWrap: 'wrap' }}>
+            {rowData.policies.map((p, index) => (
+              <Chip
+                key={`${p.permission}-${p.policy}-${index}`}
+                label={p.effect === 'allow' ? 'Allow' : 'Deny'}
+                size="small"
+                style={{
+                  backgroundColor: p.effect === 'allow' ? 'green' : 'red',
+                  color: 'white',
+                  margin: '2px',
+                }}
+              />
+            ))}
+          </Box>
+        );
       }
-      if (b.policies.length === 0) {
-        return 1;
+      return '-';
+    },
+    customSort: (a: PermissionsData, b: PermissionsData) => {
+      const isADefault = a.metadata?.source === 'default';
+      const isBDefault = b.metadata?.source === 'default';
+
+      if (isADefault && !isBDefault) {
+        return -1; // Default policies come before non-default
       }
-      if (a.policies.length === b.policies.length) {
-        return 0;
+      if (!isADefault && isBDefault) {
+        return 1;  // Non-default policies come after default
       }
-      return a.policies.length < b.policies.length ? -1 : 1;
+
+      if (isADefault && isBDefault) {
+        // Both are default, sort by effect then by permission name
+        if (a.effect && b.effect) {
+          if (a.effect !== b.effect) {
+            return a.effect.localeCompare(b.effect);
+          }
+        }
+        return a.permission.localeCompare(b.permission);
+      }
+
+      // Both are non-default (original logic, ensure policies arrays exist)
+      const aPoliciesLen = a.policies?.length ?? 0;
+      const bPoliciesLen = b.policies?.length ?? 0;
+
+      if (aPoliciesLen === 0 && bPoliciesLen > 0) { return -1; }
+      if (bPoliciesLen === 0 && aPoliciesLen > 0) { return 1; }
+      // If lengths are equal, sort by the string representation of policies (e.g. policyString)
+      // or by the first policy effect if available
+      if (aPoliciesLen === bPoliciesLen) {
+        if (aPoliciesLen === 0) return 0; // both empty
+        // Fallback to comparing permission names if policies are structurally similar or to break ties
+        return a.permission.localeCompare(b.permission);
+      }
+      return aPoliciesLen < bPoliciesLen ? -1 : 1;
     },
   },
   {

--- a/workspaces/rbac/plugins/rbac/src/components/RoleOverview/PermissionsListColumns.tsx
+++ b/workspaces/rbac/plugins/rbac/src/components/RoleOverview/PermissionsListColumns.tsx
@@ -31,6 +31,9 @@ export const columns: TableColumn<PermissionsData>[] = [
     field: 'permission',
     type: 'string',
     render: (rowData: PermissionsData) => {
+      console.log('[PermissionsListColumns] "Permission" column render, rowData:', rowData); // Log the entire rowData
+      console.log('[PermissionsListColumns] "Permission" column, rowData.metadata?.source:', rowData.metadata?.source); // Log the source specifically
+
       if (rowData.metadata?.source === 'default') {
         return (
           <Box style={{ display: 'flex', alignItems: 'center' }}>
@@ -47,6 +50,10 @@ export const columns: TableColumn<PermissionsData>[] = [
     field: 'policyString', // This field might not be directly used by the new render for defaults
     type: 'string',
     render: (rowData: PermissionsData) => {
+      console.log('[PermissionsListColumns] "Policies" column render, rowData:', rowData); // Log the entire rowData
+      console.log('[PermissionsListColumns] "Policies" column, rowData.metadata?.source:', rowData.metadata?.source); // Log the source
+      console.log('[PermissionsListColumns] "Policies" column, rowData.effect:', rowData.effect); // Log the effect
+
       if (rowData.metadata?.source === 'default') {
         if (rowData.effect === 'allow') {
           return <Chip label="Allow (Default)" size="small" style={{ backgroundColor: 'green', color: 'white', margin: '2px' }} />;

--- a/workspaces/rbac/plugins/rbac/src/types.ts
+++ b/workspaces/rbac/plugins/rbac/src/types.ts
@@ -71,6 +71,13 @@ export type PermissionsData = {
   conditions?: ConditionsData;
   resourceType?: string;
   usingResourceType?: boolean;
+  // New fields for default policies
+  effect?: string;
+  metadata?: {
+    source?: string;
+    // other metadata fields can be added if needed
+  };
+  entityReference?: string; // For '<default>' or actual role entityRef
 };
 
 /**


### PR DESCRIPTION
This change updates the RBAC permission policy to address a reviewer's recommendation regarding the handling of default permissions when deny rules are present.

Previously, the default access logic for users (even those with roles) did not explicitly check for 'deny' policies before potentially granting access based on `defaultPermissions`.

The `RBACPermissionPolicy` in `workspaces/rbac/plugins/rbac-backend/src/policies/permission-policy.ts` has been modified as follows:

1.  When `defaultUserAccessEnabled` is true and a permission request has not been explicitly allowed by other rules (`status` is false), the policy now first checks for explicit 'deny' rules associated with the user's roles for the given permission.
2.  The check considers both permission names and resource types, similar to the allow logic.
3.  If any 'deny' rules are found, access is denied, and default permissions are not applied. Audit event `permission.debug.defaultAccess.deniedByPolicy` is logged.
4.  If no 'deny' rules are found, the logic then proceeds to check if any `defaultPermissions` apply. Audit event `permission.debug.defaultAccess.noDeny` is logged.
5.  The condition `roles.length === 0` has been removed from the default permission block, allowing default permissions to apply to users with roles, provided no explicit allow or deny rules for the specific permission exist for those roles.
6.  If a matching default permission with `effect: 'allow'` is found (and no deny rules were present), access is granted. Audit event `permission.debug.defaultAccess.applied` is logged.

This ensures that explicit deny policies always take precedence over default allow policies, even when `defaultUserAccessEnabled` is active for users with roles.